### PR TITLE
Use getInheritedWidgetOfExactType in Deps.of

### DIFF
--- a/packages/flutter_spyglass/lib/src/deps_provider.dart
+++ b/packages/flutter_spyglass/lib/src/deps_provider.dart
@@ -81,7 +81,7 @@ class DepsProvider extends HookWidget {
 
   /// Obtain the nearest [Deps] scope.
   static Deps of(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<_DepsInherited>()?.deps ??
+    return context.getInheritedWidgetOfExactType<_DepsInherited>()?.deps ??
         globalDeps;
   }
 


### PR DESCRIPTION
Using dependOnInheritedWidgetOfExactType in Deps.of causes Provider to throw an error when dependency is resolved in Provider create callback. It's not technically wrong from the Flutter perspective so this change is for the sake of compatibility with the ecosystem. 

```
FlutterError (Tried to listen to an InheritedWidget in a life-cycle that will never be called again.
This error typically happens when calling Provider.of with `listen` to `true`,
in a situation where listening to the provider doesn't make sense, such as:
- initState of a StatefulWidget
- the "create" callback of a provider

This is undesired because these life-cycles are called only once in the
lifetime of a widget. As such, while `listen` is `true`, the widget has
no mean to handle the update scenario.

To fix, consider:
- passing `listen: false` to `Provider.of`
- use a life-cycle that handles updates (like didChangeDependencies)
- use a provider that handles updates (like ProxyProvider).)
```