### PR TITLE
Synchronised eager initialization

### DIFF
--- a/examples/dart_simple/bin/async_capabilities_2.dart
+++ b/examples/dart_simple/bin/async_capabilities_2.dart
@@ -7,13 +7,13 @@ Future<void> main() async {
   final sw = Stopwatch()..start();
 
   deps.addMany([
-    Dependency<UsernameProvider>(
+    Dependency<UsernameProvider>.async(
       create: (deps) async {
         await Future<void>.delayed(const Duration(seconds: 3));
         return UsernameProvider();
       },
     ),
-    Dependency<Greeter>(
+    Dependency<Greeter>.async(
       create: (deps) async {
         final usernameProvider = await deps.getAsync<UsernameProvider>();
         final username = await usernameProvider.getUsername();

--- a/examples/dart_simple/bin/async_capabilities_3.dart
+++ b/examples/dart_simple/bin/async_capabilities_3.dart
@@ -7,21 +7,21 @@ Future<void> main() async {
   final sw = Stopwatch()..start();
 
   deps.addMany([
-    Dependency<ServiceA>(
+    Dependency<ServiceA>.async(
       create: (deps) async {
         final service = ServiceA();
         await service.init();
         return service;
       },
     ),
-    Dependency<ServiceB>(
+    Dependency<ServiceB>.async(
       create: (deps) async {
         final service = ServiceB();
         await service.init();
         return service;
       },
     ),
-    Dependency<ServiceC>(
+    Dependency<ServiceC>.async(
       create: (deps) async {
         final service = ServiceC();
         await service.init();

--- a/packages/flutter_spyglass/lib/src/deps_provider.dart
+++ b/packages/flutter_spyglass/lib/src/deps_provider.dart
@@ -136,6 +136,7 @@ class DepsProvider extends HookWidget {
         }
 
         final unregister = deps.addMany(register);
+        deps.ensureAllEagerResolved();
 
         return unregister;
       },

--- a/packages/spyglass/lib/src/deps.dart
+++ b/packages/spyglass/lib/src/deps.dart
@@ -442,6 +442,20 @@ class Deps extends EventNotifier<DepsEvent> {
     ].wait;
   }
 
+  Future<void> ensureAllEagerResolved() async {
+    final eagerValues =
+        _values.values.where((v) => !v.dependency.lazy).toList();
+
+    await Future.wait([
+      for (final value in eagerValues.where((v) => v.dependency.isAsync))
+        value.resolveAsync(),
+    ]);
+
+    for (final value in eagerValues.where((v) => !v.dependency.isAsync)) {
+      value.resolve();
+    }
+  }
+
   /// Dispose of the [Deps] instance and all dependencies it contains.
   @override
   Future<void> dispose() {
@@ -485,11 +499,7 @@ extension DepsObserveMany on Deps {
 /// exposed as part of the public API.
 @internal
 class ManagedDependency<T extends Object> {
-  ManagedDependency(this.dependency, this.deps) {
-    if (!dependency.lazy) {
-      _ensureInitialized();
-    }
-  }
+  ManagedDependency(this.dependency, this.deps);
 
   final Dependency<T> dependency;
   final Deps deps;

--- a/packages/spyglass/lib/src/deps.dart
+++ b/packages/spyglass/lib/src/deps.dart
@@ -70,17 +70,33 @@ class Dependency<T extends Object> {
   /// An immutable object describing a dependency. It can be registered in [Deps]
   /// by using [Deps.add].
   const Dependency({
-    required this.create,
+    this.create,
     this.lazy = true,
     this.observe,
     this.update,
     this.dispose,
     this.tags,
     this.debugLabel,
-  }) : assert(
+  })  : assert(
           observe != null || update == null,
           'when must be provided if update is provided',
-        );
+        ),
+        createAsync = null;
+
+  const Dependency.async({
+    required Future<T> Function(Deps deps) create,
+    this.lazy = true,
+    this.observe,
+    this.update,
+    this.dispose,
+    this.tags,
+    this.debugLabel,
+  })  : assert(
+          observe != null || update == null,
+          'when must be provided if update is provided',
+        ),
+        createAsync = create,
+        create = null;
 
   /// An immutable object describing a dependency. It can be registered in [Deps]
   /// by using [Deps.add].
@@ -89,6 +105,7 @@ class Dependency<T extends Object> {
   /// over time and does not need to be lazily created.
   Dependency.value(T value, {this.tags, this.dispose, this.debugLabel})
       : create = ((_) => value),
+        createAsync = null,
         lazy = false,
         observe = null,
         update = null;
@@ -97,6 +114,9 @@ class Dependency<T extends Object> {
   /// dependency in its [Deps].
   DependencyKey get key => T;
 
+  /// Whether the dependency requires asynchronous creation.
+  bool get isAsync => createAsync != null;
+
   /// Tags can be used to categorize dependencies and perform operations on them.
   /// For example, you can use a 'startup' tag to mark dependencies that need to be
   /// initialized before the application starts. Then, use [Deps.ensureResolved] to
@@ -104,12 +124,18 @@ class Dependency<T extends Object> {
   final List<Object>? tags;
 
   /// Creates a new instance of [T]. You can use provided [Deps] to obtain
-  /// required dependencies. This callback can be asynchronous to perform
-  /// long running initialization or await another dependency.
-  final FutureOr<T> Function(Deps deps) create;
+  /// required dependencies. [createAsync] callback should be used to perform
+  /// asynchronous, long running initialization or await another dependency.
+  final T Function(Deps deps)? create;
+
+  /// Creates a new instance of [T]. You can use provided [Deps] to obtain
+  /// required dependencies. [create] callback should be used if dependency
+  /// can be create synchronously.
+  final Future<T> Function(Deps deps)? createAsync;
 
   /// Lazy dependencies are not resolved until they are explicitly requested
-  /// using [Deps.get], [Deps.getAsync] or [Deps.observe].
+  /// using [Deps.get], [Deps.getAsync] or [Deps.observe]. Eager dependencies
+  /// are resolved when ensureAllEagerResolved is called.
   final bool lazy;
 
   /// Updates or creates a new instance of the dependency in reaction to
@@ -487,7 +513,15 @@ class ManagedDependency<T extends Object> {
       throw StateError('Possibly encountered a cycle when creating dependency');
     }
     _debugCreateCalled = true;
-    _currentValue = dependency.create(deps);
+
+    if (dependency.create case final create?) {
+      _currentValue = create(deps);
+    } else if (dependency.createAsync case final createAsync?) {
+      _currentValue = createAsync(deps);
+    } else {
+      throw StateError('Dependency has no create or createAsync callback');
+    }
+
     Future.sync(() async {
       _currentValue = await _currentValue!;
       // reason: ManagedDependency and Deps work in tandem


### PR DESCRIPTION
Initialization of non-lazy dependencies during registration introduces requirements regarding registration order, i.e., a non-lazy dependency can only depend on dependencies registered before.

By delaying eager (non-lazy) initialization until `ensureAllEagerResolved`, after all registrations are complete, this issue is resolved.

`DepsProvider` widget automatically calls `ensureAllEagerResolved` however, because `ensureAllEagerResolved` has to be async, there is no guarantee that async dependencies will be available with sync `get` in the tree below.