### PR TITLE
feat: Add BlocSelector to flutter_spyglass_bloc

### DIFF
--- a/packages/flutter_spyglass_bloc/lib/flutter_spyglass_bloc.dart
+++ b/packages/flutter_spyglass_bloc/lib/flutter_spyglass_bloc.dart
@@ -4,3 +4,4 @@ export 'src/bloc_builder.dart';
 export 'src/bloc_consumer.dart';
 export 'src/bloc_dependency.dart';
 export 'src/bloc_listener.dart';
+export 'src/bloc_selector.dart';

--- a/packages/flutter_spyglass_bloc/lib/src/bloc_selector.dart
+++ b/packages/flutter_spyglass_bloc/lib/src/bloc_selector.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_spyglass/flutter_spyglass.dart';
+
+import 'bloc_builder.dart';
+
+/// Signature for the `selector` function which takes the `state` and is
+/// responsible for returning the selected value that a [BlocSelector]
+/// rebuilds on changes of.
+typedef BlocWidgetSelector<TState, TSelected> =
+    TSelected Function(TState state);
+
+/// The flutter_spyglass counterpart to flutter_bloc's `BlocSelector`.
+///
+// ignore: comment_references
+/// Resolves a [TBloc] from the nearest [Deps] scope (via [BuildContext.get])
+/// - or uses the one passed explicitly through [bloc] - and rebuilds
+/// [builder] only when [selector] returns a value that differs (via `!=`)
+/// from the previously selected one.
+///
+/// Prefer this over [BlocBuilder] with a manual `buildWhen` when only part of
+/// the state matters for the rebuild.
+class BlocSelector<TBloc extends BlocBase<TState>, TState, TSelected>
+    extends StatefulWidget {
+  /// See the class-level docs above.
+  const BlocSelector({
+    super.key,
+    required this.selector,
+    required this.builder,
+    this.bloc,
+  });
+
+  /// The bloc to build against. Defaults to `context.get<TBloc>()` - the
+  /// nearest [TBloc] registered in the [Deps] scope.
+  final TBloc? bloc;
+
+  /// Returns the value that this widget rebuilds on changes of.
+  // ignore: unsafe_variance
+  final BlocWidgetSelector<TState, TSelected> selector;
+
+  /// Builds the widget from the currently selected value.
+  // ignore: unsafe_variance
+  final BlocWidgetBuilder<TSelected> builder;
+
+  @override
+  State<BlocSelector<TBloc, TState, TSelected>> createState() =>
+      _BlocSelectorState<TBloc, TState, TSelected>();
+}
+
+class _BlocSelectorState<TBloc extends BlocBase<TState>, TState, TSelected>
+    extends State<BlocSelector<TBloc, TState, TSelected>> {
+  late TBloc _bloc;
+  late TSelected _selected;
+  StreamSubscription<TState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = widget.bloc ?? context.get<TBloc>();
+    _selected = widget.selector(_bloc.state);
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(
+    covariant BlocSelector<TBloc, TState, TSelected> oldWidget,
+  ) {
+    super.didUpdateWidget(oldWidget);
+    final oldBloc = oldWidget.bloc ?? _bloc;
+    final currentBloc = widget.bloc ?? oldBloc;
+    if (oldBloc != currentBloc) {
+      _resubscribeTo(currentBloc);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bloc == null) {
+      // Rebuild this element - and re-resolve _bloc below - whenever a new
+      // instance gets registered under TBloc, without reacting to that
+      // instance's own state changes; those are handled by _subscription.
+      final currentBloc = context.watchInstance<TBloc>();
+      if (currentBloc != _bloc) {
+        _resubscribeTo(currentBloc);
+      }
+    }
+    return widget.builder(context, _selected);
+  }
+
+  void _resubscribeTo(TBloc bloc) {
+    _subscription?.cancel();
+    _bloc = bloc;
+    _selected = widget.selector(bloc.state);
+    _subscribe();
+  }
+
+  void _subscribe() {
+    _subscription = _bloc.stream.listen((state) {
+      final selected = widget.selector(state);
+      if (selected != _selected) {
+        setState(() => _selected = selected);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+}

--- a/packages/flutter_spyglass_bloc/lib/src/bloc_selector.dart
+++ b/packages/flutter_spyglass_bloc/lib/src/bloc_selector.dart
@@ -9,8 +9,8 @@ import 'bloc_builder.dart';
 /// Signature for the `selector` function which takes the `state` and is
 /// responsible for returning the selected value that a [BlocSelector]
 /// rebuilds on changes of.
-typedef BlocWidgetSelector<TState, TSelected> =
-    TSelected Function(TState state);
+typedef BlocWidgetSelector<TState, TSelected> = TSelected Function(
+    TState state);
 
 /// The flutter_spyglass counterpart to flutter_bloc's `BlocSelector`.
 ///

--- a/packages/flutter_spyglass_bloc/test/bloc_selector_test.dart
+++ b/packages/flutter_spyglass_bloc/test/bloc_selector_test.dart
@@ -1,0 +1,129 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_spyglass_bloc/flutter_spyglass_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class Counter extends Cubit<int> {
+  Counter(super.initialState);
+}
+
+void main() {
+  testWidgets('rebuilds with the selected value and only when it changes', (
+    tester,
+  ) async {
+    final deps = Deps.detached()
+      ..add(BlocDependency<Counter>((_, __) => Counter(0)))
+      ..ensureResolved([Counter]);
+
+    var builds = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DepsProvider(
+          deps: deps,
+          introduceScope: false,
+          child: Builder(
+            builder: (context) => BlocSelector<Counter, int, bool>(
+              selector: (state) => state.isEven,
+              builder: (context, isEven) {
+                builds++;
+                return Text('$isEven');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(builds, equals(1));
+    expect(find.text('true'), findsOneWidget);
+
+    // Still even -> selected value unchanged -> no rebuild.
+    deps.get<Counter>().emit(2);
+    await tester.pumpAndSettle();
+
+    expect(builds, equals(1));
+    expect(find.text('true'), findsOneWidget);
+
+    // Odd -> selected value changes -> rebuild.
+    deps.get<Counter>().emit(3);
+    await tester.pumpAndSettle();
+
+    expect(builds, equals(2));
+    expect(find.text('false'), findsOneWidget);
+
+    await deps.dispose();
+  });
+
+  testWidgets('an explicit bloc is used instead of the one from Deps', (
+    tester,
+  ) async {
+    final deps = Deps.detached()
+      ..add(BlocDependency<Counter>((_, __) => Counter(0)))
+      ..ensureResolved([Counter]);
+    final explicitCounter = Counter(100);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DepsProvider(
+          deps: deps,
+          introduceScope: false,
+          child: Builder(
+            builder: (context) => BlocSelector<Counter, int, int>(
+              bloc: explicitCounter,
+              selector: (state) => state,
+              builder: (context, state) => Text('$state'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('100'), findsOneWidget);
+
+    explicitCounter.emit(101);
+    await tester.pumpAndSettle();
+
+    expect(find.text('101'), findsOneWidget);
+
+    await deps.dispose();
+    await explicitCounter.close();
+  });
+
+  testWidgets('rebuilds against a newly-registered bloc instance', (
+    tester,
+  ) async {
+    final deps = Deps.detached()
+      ..add(BlocDependency<Counter>((_, __) => Counter(0)))
+      ..ensureResolved([Counter]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DepsProvider(
+          deps: deps,
+          introduceScope: false,
+          child: Builder(
+            builder: (context) => BlocSelector<Counter, int, int>(
+              selector: (state) => state,
+              builder: (context, state) => Text('$state'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+
+    deps.replace(BlocDependency<Counter>((_, __) => Counter(42)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('42'), findsOneWidget);
+
+    deps.get<Counter>().emit(43);
+    await tester.pumpAndSettle();
+
+    expect(find.text('43'), findsOneWidget);
+
+    await deps.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `BlocSelector`, the flutter_spyglass counterpart to flutter_bloc's `BlocSelector`, to `flutter_spyglass_bloc` for parity with the other bloc widgets already in the package (`BlocBuilder`, `BlocListener`, `BlocConsumer`).
- Resolves the bloc from the nearest `Deps` scope (or an explicit `bloc` override) and only rebuilds `builder` when `selector` returns a value that differs (`!=`) from the previously selected one - avoiding a manual `buildWhen` when only part of the state matters.
- Exports it from `flutter_spyglass_bloc.dart`.

## Test plan
- [x] `flutter analyze` on the package - no issues
- [x] `flutter test` on the package - all 15 tests pass, including 3 new tests for `BlocSelector` (selective rebuilds, explicit `bloc` override, rebinding to a newly-registered bloc instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)